### PR TITLE
Update python/pip commands to use python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a demo data population tool created for the SE Platform demo. It does th
     - If yes: It will fire off 500 evaluations of the flag, and track metrics for it
 
 ## To use:
-1. In your terminal: `pip install -r requirements.txt`
+1. In your terminal: `pip3 install -r requirements.txt`
 1. Rename `.env.example` to `.env`
 1. Modify the `SDK_KEY` variable to the SDK key of your environment.
-1. In your terminal: `python main.py`
+1. In your terminal: `python3 main.py`


### PR DESCRIPTION
Standard mac Python 3.x environments don't have symlinks/aliases for Python 2.x-style commands `python` and `pip`.